### PR TITLE
[Feat] [SCRUM-103] 메인-페이지-API-연동: channel api 연동, 리팩토링,  useFetchData 훅 추가 #61

### DIFF
--- a/src/service/nextjs/src/component/main/body/chatting-room/index.tsx
+++ b/src/service/nextjs/src/component/main/body/chatting-room/index.tsx
@@ -4,19 +4,14 @@ import style from '../../../../style/main/body/chatting-room/index.module.css';
 interface ChattingRoomProps {
 	title: string;
 	visibility: 'public' | 'protected' | 'private';
-	numberOfPeople: number;
 }
 
-const RoomInformation = ({ title, visibility, numberOfPeople }: ChattingRoomProps) => {
+const RoomInformation = ({ title, visibility }: ChattingRoomProps) => {
 	return (
 		<div className={style.roomInformationContainer}>
 			<div>
 				<div>
 					<span>{visibility}</span>
-				</div>
-				<div>
-					<ParticipantIcon width={25} height={16} />
-					<span>{numberOfPeople}</span>
 				</div>
 			</div>
 			<div>
@@ -34,11 +29,11 @@ const IconContainer = () => {
 	);
 };
 
-const ChattingRoom = ({ title, visibility, numberOfPeople }: ChattingRoomProps) => {
+const ChattingRoom = ({ title, visibility }: ChattingRoomProps) => {
 	return (
 		<div className={style.container}>
 			<div>
-				<RoomInformation title={title} visibility={visibility} numberOfPeople={numberOfPeople} />
+				<RoomInformation title={title} visibility={visibility} />
 				<IconContainer />
 			</div>
 		</div>

--- a/src/service/nextjs/src/component/main/body/index.tsx
+++ b/src/service/nextjs/src/component/main/body/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useContext, useState } from 'react';
+import { useCallback, useContext, useEffect, useState } from 'react';
 import style from '../../../style/main/body/index.module.css';
 import ChattingRoom from './chatting-room';
 import ChattingModeToggle from './chatting-mode';
@@ -8,59 +8,118 @@ import Link from 'next/link';
 import { Box, Skeleton } from '@mui/material';
 import { useRouter } from 'next/router';
 import CustomSnackbar from '@/component/profile/modifyProfile/customSnackbar';
-import { Ban } from '@/type/channel.type';
-import AuthContext from '@/context/auth.context';
+// import AuthContext from '@/context/auth.context';
+import Chatroom from '@/type/chatroom.type';
+import { Channel, ChannelVisibility } from '@/type/channel.type';
+import useFetchData from '@/hook/useFetchData';
+import { AxiosError } from 'axios';
 
 export type ChattingMode = 'normal' | 'private';
+
+/** channel api */
+const chatData = [
+	{
+		id: '1',
+		title: 'Mockup data 1',
+		visibility: 'public' as ChannelVisibility,
+		createdAt: new Date(),
+		updatedAt: new Date(),
+	},
+	{
+		id: '2',
+		title: 'Mockup data 2',
+		visibility: 'protected' as ChannelVisibility,
+		createdAt: new Date(),
+		updatedAt: new Date(),
+	},
+	{
+		id: '3',
+		title: 'Mockup data 3',
+		visibility: 'protected' as ChannelVisibility,
+		createdAt: new Date(),
+		updatedAt: new Date(),
+	},
+	{
+		id: '4',
+		title: 'Mockup data 4',
+		visibility: 'protected ' as ChannelVisibility,
+		createdAt: new Date(),
+		updatedAt: new Date(),
+	},
+	{
+		id: '5',
+		title: 'Mockup data 5',
+		visibility: 'protected' as ChannelVisibility,
+		createdAt: new Date(),
+		updatedAt: new Date(),
+	},
+];
+
+/** chat room api */
+const dmData = [
+	{
+		id: '1',
+		title: 'Mockup data 1',
+		visibility: 'public' as ChannelVisibility,
+		createdAt: new Date(),
+		updatedAt: new Date(),
+	},
+	{
+		id: '2',
+		title: 'Mockup data 2',
+		visibility: 'protected' as ChannelVisibility,
+		createdAt: new Date(),
+		updatedAt: new Date(),
+	},
+	{
+		id: '3',
+		title: 'Mockup data 3',
+		visibility: 'protected' as ChannelVisibility,
+		createdAt: new Date(),
+		updatedAt: new Date(),
+	},
+	{
+		id: '4',
+		title: 'Mockup data 4',
+		visibility: 'protected' as ChannelVisibility,
+		createdAt: new Date(),
+		updatedAt: new Date(),
+	},
+	{
+		id: '5',
+		title: 'Mockup data 5',
+		visibility: 'protected' as ChannelVisibility,
+		createdAt: new Date(),
+		updatedAt: new Date(),
+	},
+];
 
 const MainPageBody = () => {
 	const [mode, setMode] = useState<ChattingMode>('normal');
 	const router = useRouter();
 	const [showSnackbar, setShowSnackbar] = useState(false);
 	const [message, setMessage] = useState<string>('');
-	const { me } = useContext(AuthContext);
-
-	/** channel api*/
-	const channelData = [
-		{ id: 1, title: 'Mockup data 1', visibility: 'public', numberOfPeople: 1 },
-		{ id: 2, title: 'Mockup data 2', visibility: 'protected', numberOfPeople: 2 },
-		{ id: 3, title: 'Mockup data 3', visibility: 'protected', numberOfPeople: 3 },
-		{ id: 4, title: 'Mockup data 3', visibility: 'protected', numberOfPeople: 3 },
-		{ id: 5, title: 'Mockup data 3', visibility: 'protected', numberOfPeople: 3 },
-	];
-	/** chat room api*/
-	const dmData = [
-		{ id: 1, title: 'Mockup data 1', visibility: 'public', numberOfPeople: 1 },
-		{ id: 2, title: 'Mockup data 2', visibility: 'protected', numberOfPeople: 2 },
-		{ id: 3, title: 'Mockup data 3', visibility: 'protected', numberOfPeople: 3 },
-		{ id: 4, title: 'Mockup data 3', visibility: 'protected', numberOfPeople: 3 },
-		{ id: 5, title: 'Mockup data 3', visibility: 'protected', numberOfPeople: 3 },
-	];
+	// const { me } = useContext(AuthContext);
 
 	//@todo api test
-	// const [dmDatas, setDmDatas] = useState<any[]>([]);
-	// const [isDmLoading, setDmLoading] = useState(false);
-	// const fetchData = async () => {
-	// 	try {
-	// 		setDmLoading(true);
-	// 		const res = await getFetcher('/chatroom');
-	// 		setDmDatas(res);
-	// 		setDmLoading(false);
-	// 	} catch (error) {
-	// 		console.error('Error fetching data:', error);
-	// 		setDmLoading(false);
-	// 	}
-	// };
+	/** channel api*/
+	const {
+		data: chatDatas,
+		isLoading: isChatLoading,
+		error: chatError,
+		// } = useFetchData<Channel[]>('/channel');
+	} = useFetchData<Channel[]>(null);
 
-	// useEffect(() => {
-	// 	fetchData();
-	// }, []);
-
-	// if (isDmLoading) return <Skeleton />;
-	// if (!dmDatas) return <div>DM이 없습니다.</div>;
+	/** chatroom api **/
+	const {
+		data: dmDatas,
+		isLoading: isDmLoading,
+		error: dmError,
+		// } = useFetchData<Chatroom[]>('/chatroom');
+	} = useFetchData<Chatroom[]>(null);
 
 	const navigateChannel = useCallback(
-		async (channelId: number) => {
+		async (channelId: string) => {
 			try {
 				// const banList: Ban[] = await getFetcher(`/channel/${channelId}/ban`);
 				// const isBan = banList.some(ban => ban.user.id === me?.id);
@@ -78,6 +137,34 @@ const MainPageBody = () => {
 		[router],
 	);
 
+	const getView = (
+		isLoading: boolean,
+		datas: Channel[] | Chatroom[] | undefined,
+		error: AxiosError | null,
+	) => {
+		if (isLoading) return <Skeleton />;
+		if (error) return <div>데이터를 불러오지 못했습니다.</div>;
+		if (datas?.length === 0) return <div>데이터가 없습니다.</div>;
+		return datas?.map(data => (
+			<Box
+				key={data.id}
+				onClick={() =>
+					mode === 'normal' ? navigateChannel(data?.id) : router.push(`/chat/${data?.id}/private`)
+				}
+				style={{ textDecoration: 'none' }}
+			>
+				{/*@todo dm방 제목 넣어주기*/}
+				<ChattingRoom
+					title={mode === 'normal' ? (data as Channel)?.title : 'DM방입니다.'}
+					visibility={
+						mode === 'normal'
+							? ((data as Channel)?.visibility as 'public' | 'protected')
+							: 'private'
+					}
+				/>
+			</Box>
+		));
+	};
 	return (
 		<div className={style.container}>
 			<div>
@@ -88,39 +175,11 @@ const MainPageBody = () => {
 					success={false}
 				/>
 				<ChattingModeToggle mode={mode} setMode={setMode} />
-				{mode === 'normal' ? (
-					<div style={{ overflowY: 'scroll', overflowX: 'hidden' }}>
-						{channelData?.map(data => (
-							<Box
-								key={data.id}
-								onClick={() => navigateChannel(data.id)}
-								style={{ textDecoration: 'none' }}
-							>
-								<ChattingRoom
-									title={data?.title}
-									visibility={data?.visibility as 'public' | 'protected'}
-									numberOfPeople={data?.numberOfPeople}
-								/>
-							</Box>
-						))}
-					</div>
-				) : (
-					<div style={{ overflowY: 'scroll', overflowX: 'hidden' }}>
-						{dmData?.map(data => (
-							<Link
-								key={data?.id}
-								href={`/chat/${data?.id}/private`}
-								style={{ textDecoration: 'none' }}
-							>
-								<ChattingRoom
-									title={data?.title}
-									visibility={'private'}
-									numberOfPeople={data?.numberOfPeople}
-								/>
-							</Link>
-						))}
-					</div>
-				)}
+				<div style={{ overflowY: 'scroll', overflowX: 'hidden' }}>
+					{mode === 'normal'
+						? getView(isChatLoading, chatData, chatError)
+						: getView(isDmLoading, dmData, dmError)}
+				</div>
 			</div>
 		</div>
 	);

--- a/src/service/nextjs/src/type/channel.type.ts
+++ b/src/service/nextjs/src/type/channel.type.ts
@@ -12,7 +12,7 @@ export enum ParticipantRole {
 	USER = 'USER',
 }
 
-interface Channel {
+export interface Channel {
 	id: string;
 	title: string;
 	visibility: ChannelVisibility;


### PR DESCRIPTION
## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
 - channel api 연동
 - 약간의 리팩토링
 -  useFetchData 훅 추가
## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
 - channel api 연동 -> 기존에 chat room만 연결되어있었는데 channel도 연결했습니다.
 - 리팩토링: get View 함수를 통해 chatroom 목록과 channel 목록 렌더링의 공통된 부분을 묶었습니다.
 - 채팅방 목록에 채팅 참여 인원 값(numberOfPeople)을 보여주지 않도록 했습니다. (백엔드 데이터에 없음)
 - useFetchData 훅을 추가해 api get 시 공통적으로 사용했던 상태 (isLoading: 데이터 로딩중인지, data: 불러와진 데이터, error: 데이터를 로딩하는데 실패함) 을 훅으로 가져올 수 있도록 수정했습니다.