### PR TITLE
[Fix] [SCRUM-184] channel API에서 Partial 사용 부분 PartialType으로 수정 #110

### DIFF
--- a/src/service/nestjs/src/api/channel/channel.controller.ts
+++ b/src/service/nestjs/src/api/channel/channel.controller.ts
@@ -57,8 +57,8 @@ class ChannelController {
 	@ApiNotFoundResponse({ description: 'Failed to change channel info' })
 	async updateChannel(
 		@Param('id', ParseUUIDPipe) id: string,
-		@Body() updateChannelDto: Partial<Dto.Request.Channel>,
-	) {
+		@Body() updateChannelDto: Dto.Request.UpdateChannel,
+	): Promise<Dto.Response.UpdateChannel> {
 		try {
 			return await this.channelService.updateChannel(id, updateChannelDto);
 		} catch (error) {

--- a/src/service/nestjs/src/api/channel/channel.controller.ts
+++ b/src/service/nestjs/src/api/channel/channel.controller.ts
@@ -40,7 +40,7 @@ class ChannelController {
 		type: ChannelModel,
 	})
 	@ApiNotFoundResponse({ description: 'Failed to create channel' })
-	async createChannel(@Body() channelRequestDto: Dto.Request.Channel): Promise<ChannelModel> {
+	async createChannel(@Body() channelRequestDto: Dto.Request.CreateChannel): Promise<ChannelModel> {
 		try {
 			return await this.channelService.createChannel(channelRequestDto);
 		} catch (error) {

--- a/src/service/nestjs/src/api/channel/channel.service.ts
+++ b/src/service/nestjs/src/api/channel/channel.service.ts
@@ -38,12 +38,21 @@ class ChannelService {
 		}
 	}
 
-	async updateChannel(id: string, updateChannelDto: Partial<Dto.Request.Channel>) {
+	async updateChannel(
+		id: string,
+		updateChannelDto: Dto.Request.UpdateChannel,
+	): Promise<Dto.Response.UpdateChannel> {
 		try {
-			return await this.prismaService.channel.update({
+			const updateChannel = await this.prismaService.channel.update({
 				where: { id },
 				data: updateChannelDto,
+				select: {
+					id: true,
+					updatedAt: true,
+				},
 			});
+
+			return updateChannel;
 		} catch (error) {
 			throw new Error(error.message);
 		}

--- a/src/service/nestjs/src/api/channel/channel.service.ts
+++ b/src/service/nestjs/src/api/channel/channel.service.ts
@@ -24,7 +24,7 @@ class ChannelService {
 		}
 	}
 
-	async createChannel(channelRequestDto: Dto.Request.Channel): Promise<ChannelModel> {
+	async createChannel(channelRequestDto: Dto.Request.CreateChannel): Promise<ChannelModel> {
 		try {
 			const title: string = channelRequestDto.title;
 			const visibility: ChannelVisibility = channelRequestDto.visibility;

--- a/src/service/nestjs/src/api/channel/dto/request/channel/index.ts
+++ b/src/service/nestjs/src/api/channel/dto/request/channel/index.ts
@@ -1,5 +1,5 @@
 import { Trim } from '@miaooo/class-transformer-trim';
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, PartialType } from '@nestjs/swagger';
 import { $Enums, ChannelVisibility } from '@prisma/client';
 import { IsValidPassword } from 'api/channel/decorator/is-valid-password.decorator';
 import { IsEnum, IsNotEmpty, IsString } from 'class-validator';
@@ -28,3 +28,5 @@ export class CreateChannel {
 	@ApiProperty({ description: 'Channel password', required: false })
 	password: string | null;
 }
+
+export class UpdateChannel extends PartialType(CreateChannel) {}

--- a/src/service/nestjs/src/api/channel/dto/request/channel/index.ts
+++ b/src/service/nestjs/src/api/channel/dto/request/channel/index.ts
@@ -4,7 +4,7 @@ import { $Enums, ChannelVisibility } from '@prisma/client';
 import { IsValidPassword } from 'api/channel/decorator/is-valid-password.decorator';
 import { IsEnum, IsNotEmpty, IsString } from 'class-validator';
 
-export class Channel {
+export class CreateChannel {
 	@IsString()
 	@IsNotEmpty()
 	@Trim()

--- a/src/service/nestjs/src/api/channel/dto/response/channel/index.ts
+++ b/src/service/nestjs/src/api/channel/dto/response/channel/index.ts
@@ -11,3 +11,11 @@ export class Channel {
 	@ApiProperty({ description: 'Channel visibility range.' })
 	visibility: $Enums.ChannelVisibility;
 }
+
+export class UpdateChannel {
+	@ApiProperty({ description: 'Channel id' })
+	id: string;
+
+	@ApiProperty({ required: false })
+	updatedAt: Date;
+}


### PR DESCRIPTION
## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
 - channel API에서 Partial 사용 부분 PartialType으로 수정
## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
 - `Dto.Request.Channel` -> `Dto.Request.CreateChannel` 로 수정
 - `Dto.Response.UpdateChannel` 추가
 - service의 `updateChannel` 함수의 매개변수를 `Partial` -> `PartialType`으로 수정, `Dto.Request.UpdateChannel` 추가
   - swagger에서 Request Body가 보이지 않던 문제 해결됨
 - Response Body에 `id`와 `updateAt`만 담기도록 수정