### PR TITLE
[Debug] /auth/login API 수정 #143

### DIFF
--- a/src/service/nestjs/src/api/auth/auth.controller.ts
+++ b/src/service/nestjs/src/api/auth/auth.controller.ts
@@ -7,7 +7,6 @@ import {
 	Req,
 	Request,
 	Response,
-	UnauthorizedException,
 	UseGuards,
 } from '@nestjs/common';
 import { AuthService } from './service/auth.service';
@@ -61,18 +60,21 @@ export class AuthController {
 	@ApiResponse({ status: 302, description: 'Redirect to login callback page' })
 	@ApiUnauthorizedResponse({ description: 'Unauthorized' })
 	async login(@Request() req, @Response({ passthrough: true }) res) {
-		delete req.user.iat;
-		delete req.user.exp;
+		try {
+			const user = await this.authService.login(req.user.intraId);
+			const jwt = this.cookieService.createJwt({
+				id: user.id,
+				intraId: user.intraId,
+				nickname: user.nickname,
+				profileImageURI: user.profileImageURI,
+			});
+			const cookieOption = this.cookieService.getCookieOption();
 
-		/* 다만 여기 코드 부분이 유저가 없을 경우 에러를 throw하는 부분인데 이부분을 안 지우면 /auth/login/callback까지 
-        진행되지 않아 주석 처리했습니다 */
-		// const user = await this.authService.login(req.user.intraId);
-
-		const jwt = this.cookieService.createJwt(req.user);
-		const cookieOption = this.cookieService.getCookieOption();
-
-		res.cookie('accessToken', jwt, cookieOption);
-		res.redirect(`${this.configService.getOrThrow('NEXTJS_URL')}/auth/login/callback`);
+			res.cookie('accessToken', jwt, cookieOption);
+			res.redirect(`${this.configService.getOrThrow('NEXTJS_URL')}/auth/login/callback`);
+		} catch (error) {
+			res.redirect(`${this.configService.getOrThrow('NEXTJS_URL')}/auth/register`);
+		}
 	}
 
 	@Post('register')
@@ -80,6 +82,10 @@ export class AuthController {
 	@ApiOperation({ summary: 'register' })
 	@ApiOkResponse({ description: 'Register successfully', type: User })
 	async register(@Body() registerRequestDto: Dto.Request.Register, @Req() req): Promise<User> {
-		return this.authService.register(req.user.intraId, registerRequestDto);
+		try {
+			return this.authService.register(req.user.intraId, registerRequestDto);
+		} catch (error) {
+			throw new HttpException(error.message, error.status);
+		}
 	}
 }

--- a/src/service/nestjs/src/api/auth/service/auth.service.ts
+++ b/src/service/nestjs/src/api/auth/service/auth.service.ts
@@ -1,12 +1,13 @@
 import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import UserService from 'api/user/user.service';
 import * as Dto from '../dto';
+import { UserModel } from 'common/model';
 
 @Injectable()
 export class AuthService {
 	constructor(private userSerivice: UserService) {}
 
-	async login(intraId: string) {
+	async login(intraId: string): Promise<UserModel> {
 		try {
 			const user = await this.userSerivice.findByIntraId(intraId);
 			if (!user) {


### PR DESCRIPTION
## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
 - 아예 미스 코딩이였네요 수정완료했습니다 감사합니다 @flatroad 
## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
 - login 실패 시, /auth/register로 redirect 시켜줍니다.
 - redirect된 뒤에 nickname field가 자동으로 채워져 있게 하고 싶은데, /auth/register?nickname={"nickname"} 으로 redirect 하는 방법 이외엔 redirect시에 정보를 넘길 방법이 있는지 모르겠네요 어떻게 하면 좋을 지 같이 생각해봐주실 수 있나요?
## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
 -